### PR TITLE
Ensure that user_representation and actual_user_representation match in ContentFiltering

### DIFF
--- a/rec/models/recommender.py
+++ b/rec/models/recommender.py
@@ -233,7 +233,7 @@ class BaseRecommender(MeasurementModule, SystemStateModule, VerboseMode, ABC):
         assert(user_profiles.shape[1] == item_attributes.shape[0])
         predicted_scores = np.dot(user_profiles, item_attributes)
         self.log('System updates predicted scores given by users (rows) ' + \
-            'to items (columns):\n' + str(predicted_scores))
+                 'to items (columns):\n' + str(predicted_scores))
         assert(predicted_scores is not None)
         return predicted_scores
 
@@ -395,7 +395,7 @@ class BaseRecommender(MeasurementModule, SystemStateModule, VerboseMode, ABC):
             # train between steps:
             if train_between_steps:
                 self.predicted_scores[:,:] = self.train(self.user_profiles,
-                                                   self.item_attributes)
+                                                        self.item_attributes)
             self.measure_content(interactions, step=t)
         # If no training in between steps, train at the end:
         if not train_between_steps:

--- a/rec/tests/test_ContentFiltering.py
+++ b/rec/tests/test_ContentFiltering.py
@@ -232,6 +232,12 @@ class TestContentFiltering:
         with pytest.raises(ValueError):
             c = ContentFiltering(user_representation=user_repr,
                                  item_representation=bad_item_repr)
+        with pytest.raises(ValueError):
+            # actual user prefs and system's representation of user's prefs
+            # must be the same dimension 
+            c = ContentFiltering(user_representation=user_repr,
+                                 actual_user_representation=bad_user_repr,
+                                 item_representation=bad_item_repr)
 
     def test_additional_params(self, num_items_per_iter=None):
         if num_items_per_iter is None:

--- a/rec/utils.py
+++ b/rec/utils.py
@@ -39,6 +39,13 @@ def is_array_valid_or_none(array, ndim=2):
     # all good
     return True
 
+def array_dimensions_match(array1, array2):
+    """ Assuming that both arrays are defined,
+        we test whether they have matching dimensions.
+    """
+    array1, array2 = np.asarray(array1), np.asarray(array2)
+    return array1.shape == array2.shape
+
 def is_valid_or_none(value, type):
     """Returns true if either None or of the specified type"""
     return value is None or isinstance(value, type)


### PR DESCRIPTION
This PR closes issue #41. 

If a `ContentFiltering` model is created with a parameter passed in for `actual_user_representation`, then an error will arise within the `train` function of `BaseRecommender`. This is because the `__init__` function of `ContentFiltering` only infers the number of users/attributes from `user_representation` and `item_representation`, but fails to consider `actual_user_representation`. 

I correct this in the `__init__` function and also add a helper function to `utils` called `array_dimensions_match` to ensure that `user_representation` and `actual_user_representation` have the same dimensions, if the user passes both in.

# Result

![image](https://user-images.githubusercontent.com/5581093/92279900-240ff580-eead-11ea-943f-ea4b80d8c9d8.png)
_look ma, no errors!_