### PR TITLE
Reformat code/comments in rec/metrics

### DIFF
--- a/rec/metrics/__init__.py
+++ b/rec/metrics/__init__.py
@@ -1,1 +1,8 @@
-from .measurement import Measurement, HomogeneityMeasurement, MSEMeasurement, DiffusionTreeMeasurement, StructuralVirality, InteractionMeasurement
+from .measurement import (
+    Measurement,
+    HomogeneityMeasurement,
+    MSEMeasurement,
+    DiffusionTreeMeasurement,
+    StructuralVirality,
+    InteractionMeasurement,
+)

--- a/rec/metrics/measurement.py
+++ b/rec/metrics/measurement.py
@@ -3,6 +3,7 @@ from rec.utils import VerboseMode
 from rec.components import BaseObservable
 import numpy as np
 
+
 class Measurement(BaseObservable, VerboseMode, ABC):
     """
     Abstract observable class to store measurements.
@@ -22,6 +23,7 @@ class Measurement(BaseObservable, VerboseMode, ABC):
         measurement_history: list
             List of measurements. A new element is added at each timestep.
     """
+
     def __init__(self, verbose=False, init_value=None):
         VerboseMode.__init__(self, __name__.upper(), verbose)
         self.measurement_history = list()
@@ -31,7 +33,9 @@ class Measurement(BaseObservable, VerboseMode, ABC):
 
     def get_measurement(self):
         """
-        Returns measurements. See :func:`~components.base_components.BaseObservable.get_observable` for more details.
+        Returns measurements. See
+        :func:`~components.base_components.BaseObservable.get_observable`
+        for more details.
 
         Returns
         --------
@@ -41,7 +45,8 @@ class Measurement(BaseObservable, VerboseMode, ABC):
 
     def observe(self, observation, copy=True):
         """
-        Stores measurements. It can be called by implementations to ensure consistency when storing different measurements.
+        Stores measurements. It can be called by implementations to ensure
+        consistency when storing different measurements.
 
         Parameters
         -----------
@@ -50,7 +55,8 @@ class Measurement(BaseObservable, VerboseMode, ABC):
             Element that will be stored
 
         copy: bool (optional, default: True)
-            If True, the function stores a copy of observation. Useful for :obj:`numpy.ndarray`.
+            If True, the function stores a copy of observation. Useful for
+            :obj:`numpy.ndarray`.
 
         """
         if copy:
@@ -65,7 +71,8 @@ class Measurement(BaseObservable, VerboseMode, ABC):
 
     def get_timesteps(self):
         """
-        Returns the number of measurements stored (which is equivalent to the number of timesteps that the system has been measuring).
+        Returns the number of measurements stored (which is equivalent to the
+        number of timesteps that the system has been measuring).
 
         Returns
         --------
@@ -79,7 +86,8 @@ class InteractionMeasurement(Measurement):
     """
     Keeps track of the interactions between users and items.
 
-    Specifically, at each timestep, it stores a histogram of length `|I|`, where element `i` is the number of interactions received by item `i`.
+    Specifically, at each timestep, it stores a histogram of length `|I|`, where
+    element `i` is the number of interactions received by item `i`.
 
     Parameters
     -----------
@@ -94,13 +102,15 @@ class InteractionMeasurement(Measurement):
         name: str
             Name of the measurement component.
     """
+
     def __init__(self, verbose=False):
-        self.name = 'interaction_histogram'
+        self.name = "interaction_histogram"
         Measurement.__init__(self, verbose, init_value=None)
 
     def _generate_interaction_histogram(self, interactions, num_users, num_items):
         """
-        Generates a histogram of the number of interactions per item at the given timestep.
+        Generates a histogram of the number of interactions per item at the
+        given timestep.
 
         Parameters
         -----------
@@ -122,12 +132,13 @@ class InteractionMeasurement(Measurement):
         histogram = np.zeros(num_items)
         np.add.at(histogram, interactions, 1)
         # Check that there's one interaction per user
-        assert(histogram.sum() == num_users)
+        assert histogram.sum() == num_users
         return histogram
 
     def measure(self, step, interactions, recommender):
         """
-            Measures and stores a histogram of the number of interactions per item at the given timestep.
+            Measures and stores a histogram of the number of interactions per
+            item at the given timestep.
 
             Parameters
             ------------
@@ -136,16 +147,18 @@ class InteractionMeasurement(Measurement):
                     Current time step
 
                 interactions: :obj:`numpy.array`
-                    Non-aggregated array of interactions -- that is, an array of length `|U|` s.t. element `u` is the index of the item with which user `u` interacted.
+                    Non-aggregated array of interactions -- that is, an array of
+                    length `|U|` s.t. element `u` is the index of the item with
+                    which user `u` interacted.
 
                 recommender: :class:`~models.recommender.BaseRecommender`
                     Model that inherits from :class:`~models.recommender.BaseRecommender`.
         """
 
-        histogram = self._generate_interaction_histogram(interactions,
-                                                         recommender.num_users,
-                                                         recommender.num_items)
-        #histogram[::-1].sort()
+        histogram = self._generate_interaction_histogram(
+            interactions, recommender.num_users, recommender.num_items
+        )
+        # histogram[::-1].sort()
         self.observe(histogram, copy=True)
 
 
@@ -153,7 +166,8 @@ class HomogeneityMeasurement(InteractionMeasurement):
     """
     Measures the homogeneity of the interactions between users and items.
 
-    Specifically, at each timestep, it measures whether interactions are spread among many items or only a few items.
+    Specifically, at each timestep, it measures whether interactions are spread
+    among many items or only a few items.
 
     This class inherits from :class:`.InteractionMeasurement`.
 
@@ -173,15 +187,17 @@ class HomogeneityMeasurement(InteractionMeasurement):
         _old_histogram: None, list, array_like
             A copy of the histogram at the previous timestep.
     """
+
     def __init__(self, verbose=False):
         self.histogram = None
         self._old_histogram = None
-        self.name = 'homogeneity'
+        self.name = "homogeneity"
         Measurement.__init__(self, verbose, init_value=None)
 
     def measure(self, step, interactions, recommender):
         """
-            Measures the homogeneity of user interactions -- that is, whether interactions are spread among many items or only a few items.
+            Measures the homogeneity of user interactions -- that is, whether
+            interactions are spread among many items or only a few items.
 
             Parameters
             ------------
@@ -190,20 +206,24 @@ class HomogeneityMeasurement(InteractionMeasurement):
                     Current time step
 
                 interactions: :obj:`numpy.array`
-                    Non-aggregated array of interactions -- that is, an array of length `|U|` s.t. element `u` is the index of the item with which user `u` interacted.
+                    Non-aggregated array of interactions -- that is, an array of
+                    length `|U|` s.t. element `u` is the index of the item with
+                    which user `u` interacted.
 
                 recommender: :class:`~models.recommender.BaseRecommender`
-                    Model that inherits from :class:`~models.recommender.BaseRecommender`.
+                    Model that inherits from
+                    :class:`~models.recommender.BaseRecommender`.
         """
-        assert(interactions.size == recommender.num_users)
-        histogram = self._generate_interaction_histogram(interactions,
-                                                         recommender.num_users,
-                                                         recommender.num_items)
+        assert interactions.size == recommender.num_users
+        histogram = self._generate_interaction_histogram(
+            interactions, recommender.num_users, recommender.num_items
+        )
         histogram[::-1].sort()
         if self._old_histogram is None:
             self._old_histogram = np.zeros(recommender.num_items)
-        self.observe(np.trapz(self._old_histogram, dx=1) - np.trapz(histogram, dx=1),
-                     copy=False)
+        self.observe(
+            np.trapz(self._old_histogram, dx=1) - np.trapz(histogram, dx=1), copy=False
+        )
         self._old_histogram = np.copy(histogram)
         self.histogram = histogram
 
@@ -229,13 +249,15 @@ class MSEMeasurement(Measurement):
         name: str
             Name of the measurement component.
     """
+
     def __init__(self, verbose=False):
-        self.name = 'mse'
+        self.name = "mse"
         Measurement.__init__(self, verbose, init_value=None)
 
     def measure(self, step, interactions, recommender):
         """
-        Measures and records the mean squared error between the user preferences predicted by the system and the users' actual preferences.
+        Measures and records the mean squared error between the user preferences
+        predicted by the system and the users' actual preferences.
 
         Parameters
         ------------
@@ -244,22 +266,32 @@ class MSEMeasurement(Measurement):
                 Current time step
 
             interactions: :obj:`numpy.array`
-                Non-aggregated array of interactions -- that is, an array of length `|U|` s.t. element `u` is the index of the item with which user `u` interacted.
+                Non-aggregated array of interactions -- that is, an array of
+                length `|U|` s.t. element `u` is the index of the item with
+                which user `u` interacted.
 
             recommender: :class:`~models.recommender.BaseRecommender`
                 Model that inherits from :class:`~models.recommender.BaseRecommender`.
         """
-        self.observe(((recommender.predicted_scores -
-            recommender.actual_users.actual_user_scores)**2).mean(), copy=False)
+        diff = (
+            recommender.predicted_scores - recommender.actual_users.actual_user_scores
+        )
+        self.observe((diff ** 2).mean(), copy=False)
 
 
 class DiffusionTreeMeasurement(Measurement):
     """
-    Class that implements an information diffusion tree. The current implementation assumes that agents using this class (i.e., a model) implement an :attr:`~models.bass.BassModel.infection_state` matrix that denotes the initial state of information.
+    Class that implements an information diffusion tree. The current
+    implementation assumes that agents using this class (i.e., a model)
+    implement an :attr:`~models.bass.BassModel.infection_state` matrix that
+    denotes the initial state of information.
 
-    In this implementation, the nodes represent users and are labeled with the user indices. A branch between nodes `u` and `v` indicates that user `u` passed information onto user `v` -- that is, `u` "infected" `v`.
+    In this implementation, the nodes represent users and are labeled with the
+    user indices. A branch between nodes `u` and `v` indicates that user `u`
+    passed information onto user `v` -- that is, `u` "infected" `v`.
 
-    Trees are implemented using the `Networkx library`_. Please refer to Networkx's `documentation`_ for more details.
+    Trees are implemented using the `Networkx library`_. Please refer to
+    Networkx's `documentation`_ for more details.
 
     .. _Networkx library: http://networkx.github.io
     .. _documentation: https://networkx.github.io/documentation/stable/
@@ -278,7 +310,11 @@ class DiffusionTreeMeasurement(Measurement):
         Inherited by Measurement: :class:`.Measurement`
 
         name: str
-            Name of the metric that is recorded at each time step. Note that, in this case, the metric stored in :attr:`~.Measurement.measurement_history` is actually the **number of infected users**. The diffusion tree itself is kept in the :attr:`.diffusion_tree` data structure.
+            Name of the metric that is recorded at each time step. Note that,
+            in this case, the metric stored in
+            :attr:`~.Measurement.measurement_history` is actually the
+            **number of infected users**. The diffusion tree itself is kept in
+            the :attr:`.diffusion_tree` data structure.
 
         diffusion_tree: :obj:`networkx.Graph`
             Diffusion tree.
@@ -286,15 +322,18 @@ class DiffusionTreeMeasurement(Measurement):
         _old_infection_state: array_like
             Infection state at the previous timestep.
     """
+
     def __init__(self, infection_state, verbose=False):
         import networkx as nx
-        self.name = 'num_infected'
+
+        self.name = "num_infected"
         self._old_infection_state = None
         self.diffusion_tree = nx.Graph()
         self._manage_new_infections(None, np.copy(infection_state))
         self._old_infection_state = np.copy(infection_state)
-        Measurement.__init__(self, verbose,
-            init_value=self.diffusion_tree.number_of_nodes())
+        Measurement.__init__(
+            self, verbose, init_value=self.diffusion_tree.number_of_nodes()
+        )
 
     def _find_parents(self, user_profiles, new_infected_users):
         if (self._old_infection_state == 0).all():
@@ -304,8 +343,8 @@ class DiffusionTreeMeasurement(Measurement):
         # candidates must have been previously infected
         prev_infected_users = np.where(self._old_infection_state > 0)[0]
         # candidates must be connected to newly infected users
-        candidate_parents = user_profiles[:,prev_infected_users][new_infected_users]
-        parents = prev_infected_users[np.argsort(candidate_parents)[:,-1]]
+        candidate_parents = user_profiles[:, prev_infected_users][new_infected_users]
+        parents = prev_infected_users[np.argsort(candidate_parents)[:, -1]]
         return parents
 
     def _add_to_graph(self, user_profiles, new_infected_users):
@@ -319,19 +358,21 @@ class DiffusionTreeMeasurement(Measurement):
     def _manage_new_infections(self, user_profiles, current_infection_state):
         if self._old_infection_state is None:
             self._old_infection_state = np.zeros(current_infection_state.shape)
-        new_infections = (current_infection_state -
-                            self._old_infection_state)
+        new_infections = current_infection_state - self._old_infection_state
         if (new_infections == 0).all():
             # no new infections
             return 0
-        new_infected_users = np.where(new_infections > 0)[0] # only the rows
+        new_infected_users = np.where(new_infections > 0)[0]  # only the rows
         self._add_to_graph(user_profiles, new_infected_users)
         # return number of new infections
         return new_infected_users.shape[0]
 
     def measure(self, step, interactions, recommender):
         """
-        Updates tree with new infections and stores information about new infections. In :attr:`~.Measurement.measurement_history`, it stores the total number of infected users in the system -- that is, the number of nodes in the tree.
+        Updates tree with new infections and stores information about new
+        infections. In :attr:`~.Measurement.measurement_history`, it stores the
+        total number of infected users in the system -- that is, the number of
+        nodes in the tree.
 
         Parameters
         ------------
@@ -340,13 +381,16 @@ class DiffusionTreeMeasurement(Measurement):
                 Current time step
 
             interactions: :obj:`numpy.array`
-                Non-aggregated array of interactions -- that is, an array of length `|U|` s.t. element `u` is the index of the item with which user `u` interacted.
+                Non-aggregated array of interactions -- that is, an array of
+                length `|U|` s.t. element `u` is the index of the item with
+                which user `u` interacted.
 
             recommender: :class:`~models.recommender.BaseRecommender`
                 Model that inherits from :class:`~models.recommender.BaseRecommender`.
         """
-        num_new_infections = self._manage_new_infections(recommender.user_profiles,
-            recommender.infection_state)
+        num_new_infections = self._manage_new_infections(
+            recommender.user_profiles, recommender.infection_state
+        )
         self.observe(self.diffusion_tree.number_of_nodes(), copy=False)
         self._old_infection_state = np.copy(recommender.infection_state)
 
@@ -356,12 +400,16 @@ class DiffusionTreeMeasurement(Measurement):
         """
         import matplotlib.pyplot as plt
         import networkx as nx
+
         nx.draw(self.diffusion_tree, with_labels=True)
 
 
 class StructuralVirality(DiffusionTreeMeasurement):
     """
-    This class extends :class:`DiffusionTreeMeasurement` with the concept of structural virality developed by Goel, Anderson, Hofman, and Watts in `The Structural Virality of Online Diffusion`_. It is used in :class:`~models.bass.BassModel`.
+    This class extends :class:`DiffusionTreeMeasurement` with the concept of
+    structural virality developed by Goel, Anderson, Hofman, and Watts in
+    `The Structural Virality of Online Diffusion`_. It is used in
+    :class:`~models.bass.BassModel`.
 
     .. _The Structural Virality of Online Diffusion: https://5harad.com/papers/twiral.pdf
 
@@ -372,6 +420,7 @@ class StructuralVirality(DiffusionTreeMeasurement):
             The initial "infection state" (see :class:`DiffusionTreeMeasurement`).
 
     """
+
     def __init__(self, infection_state, verbose=False):
         DiffusionTreeMeasurement.__init__(self, infection_state, verbose)
 
@@ -385,5 +434,6 @@ class StructuralVirality(DiffusionTreeMeasurement):
         """
         import networkx as nx
         from networkx.algorithms.wiener import wiener_index
+
         n = self.diffusion_tree.number_of_nodes()
         return nx.wiener_index(self.diffusion_tree) / (n * (n - 1))


### PR DESCRIPTION
reformatted to `black`'s standards:
![image](https://user-images.githubusercontent.com/5581093/92648536-69159c80-f29e-11ea-9818-c5191cd9643c.png)

proof all tests pass:
![image](https://user-images.githubusercontent.com/5581093/92648551-6e72e700-f29e-11ea-89d5-cf4dfeef0c5f.png)
